### PR TITLE
AD-HOC feat (*): Add initial Lets Encrypt role

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+# Ansible Lets Encrypt role
+
+This is the Ansible lets-encrypt role. It's designed for consumption by playbooks, not for consumption by
+itself.
+
+## Requirements
+
+- Internet Access
+- Ansible 2.4.0+
+- Python2[1](https://github.com/ansible/ansible/issues/30690)
+- pip (installs dependencies if required)
+
+## Caveats
+
+### Limited Support
+
+While the role was written in an extensible way, and wll be extended as requirements dicatate to include other
+Lets Encrypt auth mechanisms or cloud providers, only DNS by Route53 has been implemented so far.
+
+### Manually combines full chain
+
+At this time, it is not possible to fetch the full chain from Ansible[3](https://github.com/ansible/ansible/pull/22074).
+Given this, the current certificate chain is manually constructed from what's available on Lets Encrypt publicly.
+This may go out of date or otherwise break.
+
+### Only DNS SANs are supported
+
+This is a limitation of Lets Encrypt upstream[2](https://community.letsencrypt.org/t/register-ip-as-san-for-my-domain/12703)
+Given this, the limitation is also part of the role. Should this limitation be revised in future, this role will need
+to be refactored.
+
+### Does not install self renewing software
+
+This does not install something like certbot etc. to self renew software. It does renew certificates early (30 days by
+default), but the role of Ansible is to run machines including PKI / expiring certificates.
+
+## Usage
+
+Include this in another ansible playbook. For sample, consider a generic server playbook:
+
+```
+---
+# $PLAYBOOK_ROOT/server.yaml
+- name: "server"
+  hosts: all
+  become: true
+  become_user: "root"
+```
+
+Add the reference for the role:
+
+```
+# $PLAYBOOK_ROOT/server.yaml
+# ...
+become_user: "root"
+roles
+  - "sitewards.lets-encrypt"
+```
+
+This will allow the role to be discovered. Then, add this repo as a submodule:
+
+```
+$ cd path/to/playbook/root
+$ mkdir roles/
+$ git submodule add https://github.com/sitewards/ansible-role-lets-encrypt roles/sitewards.lets-encrypt
+```
+
+This should work!
+
+## Configuration
+
+The variables that are available are defined in defaults/main.yml. There are various requirements; check the file for
+further details.
+
+## Contact
+
+https://www.sitewards.com/

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,77 @@
+---
+## The python package for pyopenssl; a requirement for the openssl task
+lets_encrypt_python_package: "python3-openssl"
+
+## The account email for Lets Encrypt.
+## (Required)
+# lets_encrypt_account_email:
+
+## The directory used for Lets Encrypt to generate certificates
+## Defaults to staging for testing.
+lets_encrypt_directory: "https://acme-staging.api.letsencrypt.org/directory"
+
+## How many days before the certificate expires it should be renewed
+lets_encrypt_renew_limit: 30
+
+## The resource name. Most often, this will be the fqdn of the site.
+lets_encrypt_resource_name: "website"
+
+## The type of challenge that Lets Encrypt performs to check the server exists.
+## Should be one of:
+## - http-01
+## - dns-01
+## - tls-sni-02
+lets_encrypt_challenge_type: "dns-01"
+
+## The common or "root" name of this TLS certificate
+## (Required)
+# lets_encrypt_common_name:
+
+## A list of the alternative names that the TLS certificate can make available. This can be a set of domains, such as
+## DNS:sitewards.com
+## DNS:www.sitewards.com
+##
+## Must be prefixed with the appropriate spec (DNS, IP)
+lets_encrypt_subject_alt_names: [""]
+
+## The country name for the CSR. A full list of country codes can be found here:
+## https://clients.hostingireland.ie/knowledgebase/2042/2-letter-country-codes-for-CSR-generation.html
+## (Required)
+# lets_encrypt_csr_country_name: "DE"
+
+## The state (locality) of the organisation for the CSR
+## (Required)
+# lets_encrypt_csr_locality_name: "Hessen"
+
+## The organisation responsible for the service behind TLS
+## (Required)
+# lets_encrypt_csr_organization_name:
+
+## The organisational unit responsible for the service behind TLS
+## (Required)
+# lets_encrypt_csr_organizational_unit_name
+
+## The email address of the CSR to use
+## (Required)
+# lets_encrypt_csr_email_address: "example.user@sitewards.com"
+
+# At least some of the below options are required. See README for further details.
+
+## The DNS provider used to validate the request. Can be one of:
+## - route53
+# lets_encrypt_validation_provider:
+
+## The path to the public directory used to validate the Lets Encrypt resources
+## (Currently unused)
+# lets_encrypt_http_path:
+
+# Cloud specific options. May be required, depending on the mechanism used to prove identity of the connctoin.
+
+## The AWS IAM users access key
+# lets_encrypt_aws_access_key_id
+
+## The AWS IAM users
+# lets_encrypt_aws_secret_access_key
+
+## The AWS Route53 zone to modify during provisioning
+# lets_encrypt_aws_route53_dns_zone

--- a/tasks/dependencies.yml
+++ b/tasks/dependencies.yml
@@ -1,0 +1,8 @@
+---
+- name: "Ensure the pyopenssl package is available"
+  pip:
+    name: "{{ item }}"
+    state: "latest"
+  with_items:
+    - pyopenssl
+    - boto

--- a/tasks/lets_encrypt.yml
+++ b/tasks/lets_encrypt.yml
@@ -1,0 +1,119 @@
+---
+# Need to append https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt
+- name: "Initial set of certificate validation"
+  set_fact:
+    certificate_invalidated: false
+
+- name: "Create a build directory for fullchain assembly"
+  tempfile:
+    state: "directory"
+    suffix: "pki"
+  register: "build_dir"
+
+- name: "Create the base PKI directories"
+  file:
+    path: "{{ item.path }}"
+    owner: "root"
+    group: "root"
+    mode: "{{ item.permissions }}"
+    state: "directory"
+  with_items:
+    - path: "/etc/ssl/private"
+      permissions: "u=rwx,g=,o="
+    - path: "/etc/ssl/certs"
+      permissions: "u=rwx,g=rx,o=rx"
+    - path: "/etc/ssl/requests"
+      permissions: "u=rwx,g=o,o="
+
+- name: "Create the Lets Encrypt signing key"
+  openssl_privatekey:
+    path: "/etc/ssl/private/lets_encrypt.key"
+
+- name: "Create the resource wide key"
+  openssl_privatekey:
+    path: "/etc/ssl/private/{{ lets_encrypt_resource_name }}.key"
+
+- name: "Create the certificate signing request"
+  openssl_csr:
+    path: "/etc/ssl/requests/{{ lets_encrypt_resource_name }}.csr"
+    privatekey_path: "/etc/ssl/private/{{ lets_encrypt_resource_name }}.key"
+    state: "present"
+    common_name: "{{ lets_encrypt_common_name }}"
+    country_name: "{{ lets_encrypt_csr_country_name }}"
+    locality_name: "{{ lets_encrypt_csr_locality_name }}"
+    organization_name: "{{ lets_encrypt_csr_organization_name }}"
+    organizational_unit_name: "{{ lets_encrypt_csr_organizational_unit_name }}"
+    email_address: "{{ lets_encrypt_csr_email_address }}"
+    subject_alt_name: "{{ lets_encrypt_subject_alt_names }}"
+
+- name: "Make the request of the Lets Encrypt API"
+  letsencrypt:
+    remaining_days: "{{ lets_encrypt_renew_limit }}"
+    acme_directory: "{{ lets_encrypt_directory }}"
+    account_email: "{{ lets_encrypt_account_email }}"
+    account_key: "/etc/ssl/private/lets_encrypt.key"
+    challenge: "{{ lets_encrypt_challenge_type }}"
+    csr: "/etc/ssl/requests/{{ lets_encrypt_resource_name }}.csr"
+    dest: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.crt"
+  register: acme_data
+
+- name: "Set whether needs update"
+  set_fact:
+    certificate_invalidated: true
+  when: acme_data.challenge_data is not undefined
+
+- include_tasks: "providers/{{ lets_encrypt_challenge_type }}/{{ lets_encrypt_validation_provider }}.yml"
+  vars:
+    state: "present"
+  with_items: "{{ lets_encrypt_subject_alt_names }}"
+  when: certificate_invalidated == true
+
+- name: "Await propagation of the DNS records"
+  pause:
+    seconds: 30
+  when:
+    - lets_encrypt_challenge_type == "dns-01"
+    - certificate_invalidated == true
+
+- name: "Ask Lets Encrypt to validate and issue a new key"
+  letsencrypt:
+    acme_directory: "{{ lets_encrypt_directory }}"
+    account_key: "/etc/ssl/private/lets_encrypt.key"
+    challenge: "{{ lets_encrypt_challenge_type }}"
+    csr: "/etc/ssl/requests/{{ lets_encrypt_resource_name }}.csr"
+    dest: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.crt"
+    data: "{{ acme_data }}"
+  when: certificate_invalidated == true
+
+# Clean up the Route53 records
+- include_tasks: "providers/{{ lets_encrypt_challenge_type }}/{{ lets_encrypt_validation_provider }}.yml"
+  vars:
+    state: "absent"
+  with_items: "{{ lets_encrypt_subject_alt_names }}"
+  when: certificate_invalidated == true
+
+- name: "Copy the issued certificate to the build dir for assembly"
+  copy:
+    src: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.crt"
+    dest: "{{ build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
+    remote_src: "yes"
+  when: certificate_invalidated == true
+
+- name: "Fetch the CA certificate"
+  get_url:
+    url: "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt"
+    dest: "{{ build_dir.path }}/02-chain.crt"
+  when: certificate_invalidated == true
+
+- name: "Assemble the full chain"
+  assemble:
+    src: "{{ build_dir.path }}"
+    dest: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.fullchain.crt"
+    owner: "root"
+    mode: "u=r,g=r,o=r"
+  when: certificate_invalidated == true
+
+- name: "Cleanup build dir"
+  file:
+    state: "absent"
+    path: "{{ build_dir.path }}/"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+- include: "dependencies.yml"
+- include: "lets_encrypt.yml"

--- a/tasks/providers/dns-01/route53.yml
+++ b/tasks/providers/dns-01/route53.yml
@@ -1,0 +1,17 @@
+---
+- name: "Create the domain from the SAN indicator"
+  set_fact:
+    fqdn: "{{ item | regex_replace('^DNS:', '') }}"
+
+# Note that TXT and SPF records must be surrounded by quotes when sent to Route 53:
+- name: "Ensure the TXT record in Route53 is up to date"
+  route53:
+    aws_access_key: "{{ lets_encrypt_aws_access_key_id }}"
+    aws_secret_key: "{{ lets_encrypt_aws_secret_access_key }}"
+    overwrite: True
+    state: "{{ state }}"
+    zone: "{{ lets_encrypt_aws_route53_dns_zone }}"
+    record: "{{ acme_data.challenge_data[fqdn]['dns-01']['resource'] }}.{{ fqdn }}"
+    type: "TXT"
+    ttl: 300
+    value: "\"{{ acme_data.challenge_data[fqdn]['dns-01']['resource_value'] }}\""


### PR DESCRIPTION
There are quite some areas where Lets Encrypt is extremely handy for
issuing certificates. They are a valid CA, and coming to more accepted
use within the industry. They are also outstandingly easy to automate.

This commit creates a role that provisions Lets Encrypt certificate.

Design Notes:

debian SSL dirs:

  This role is basically limited to Debian. It has not been tested on
  RHEL (though no effort has been made to make it difficult, and it
  should be easily extensible). The Debian PKI dir style was chosen
  over the RHEL style simply as it was handy.

Route53 Overwrite:

  This includes a Route53 task that overwrites existing TXT records.
  The changes of a collision are extremely minimal (it would be a bug
  in the role or old Lets Encrypt records), and it is useful to have
  them work regardless so that if the role fails due to failed
  validation, the next role will JustWork(tm)

Pause for propagation of DNS:

  The task pauses to allow DNS to propagate. Though it should be
  instant, during testing it was not always the case. The time period
  is arbitrary, but not so long, and worked consistently.

Provider Model:

  The role uses a provider model, allowing it to be extended with
  arbitrary validations in future. This should allow easy porting for
  HTTP or other cloud providers.