### PR TITLE
AD-HOC feat (Tasks): Allow opting out

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ This should work!
 The variables that are available are defined in defaults/main.yml. There are various requirements; check the file for
 further details.
 
+## Debugging
+
+The task can be skipped by not defining a "lets_encrypt_common_name" variable (undefined by default). This is configured
+so that the role can be provisioned across all environments (including internally, where there is no mechanism to
+validate lets encrypt).
+
+Should the task be skipping, take a look at that.
+
 ## Contact
 
 https://www.sitewards.com/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,4 @@
 ---
 - include: "dependencies.yml"
 - include: "lets_encrypt.yml"
+  when: lets_encrypt_common_name is not undefined


### PR DESCRIPTION
It is the authors opinion that when ansible tasks create resources or
modify state, it should be possible for the playbook to "opt out" of the
role simply by specifying that there be zero state created. An example
of this would be a role that managers linux users. The task (in psuedo
code) does:

  for all users; do
    create user;
  done;

Where there are zero users present, there are zero users created.

This commit replicates this behaviour by skipping the entire role if the
variable "letsencrypt_common_name" is undefined. This is a required
variable; it's absence means the task will fail. So, it can reasonably
be skipped given it's absence.

Design Notes:

alternative design: allow multiple certificates

  A better way to do this would be to extend the role to allow multiple
  certificate provisioning. In this way, the "bare" resources can be
  created (i.e. the Lets Encrypt signing key) but no actual certificates
  provisioned. However, the author does not have the time to complete
  this change.