### PR TITLE
Adhoc decrease acme challenge resource record's TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ itself.
 | type      | The type of provider that will be implementing the required authorisation                                        |
 
 ## Caveats
+Please Note that the lets_encrypt_common_name and all domains configured in lets_encrypt_resources should resolve and have valid A records.
 
 ### Limited Support
 

--- a/tasks/providers/dns-01/route53.yml
+++ b/tasks/providers/dns-01/route53.yml
@@ -21,5 +21,5 @@
     zone: "{{ lets_encrypt_provider_configuration['zone'] }}"
     record: "{{ acme_data.challenge_data[lets_encrypt_resource_domain]['dns-01']['resource'] }}.{{ lets_encrypt_resource_domain }}"
     type: "TXT"
-    ttl: 300
+    ttl: 1
     value: "\"{{ acme_data.challenge_data[lets_encrypt_resource_domain]['dns-01']['resource_value'] }}\""


### PR DESCRIPTION
TTL of the acme challenge rr is currently 5 minutes.
If runs the LE role within that time frame, request might break with error below:

msg: Authorization for ******** returned invalid:
CHALLENGE: ******** DETAILS: DNS problem: NXDOMAIN looking up TXT for ********.********;

This is due to timing issue LE using cached TXT rr.
We decrease the TTL from 300 seconds to 1 second as to prevent that error.