### PR TITLE
AD-HOC fix (domain names) Change regex so it only prefies 'DNS:' once per Domain

### DIFF
--- a/tasks/lets_encrypt.yml
+++ b/tasks/lets_encrypt.yml
@@ -37,8 +37,9 @@
 - name: "Create the list of domains valid for this certificate"
   set_fact:
     lets_encrypt_domains: "{{ lets_encrypt_resources | json_query('[*].domain') | list }}"
-- set_fact:
-    lets_encrypt_subject_alt_names: "{{ lets_encrypt_domains | map('regex_replace', '(.*)', 'DNS:\\1') | list }}"
+- name: "Create the list of alt domains valid for this certificate"
+  set_fact:
+    lets_encrypt_subject_alt_names: "{{ lets_encrypt_domains | map('regex_replace', '^(.*)$', 'DNS:\\1') | list }}"
 
 - name: "Create the certificate signing request"
   openssl_csr:


### PR DESCRIPTION
While using this Role to setup a project, I got an error response from
lets encrypt api that was refusing the refusing the crt-request. A bit
of investigation shows that the alternative domain name was converted to
'DNS:example.comDNS:' The 'DNS:' at the end of the string should not be
there. The provided fix is making shure the regex is matching the whole
sting, so the alternate domain is now 'DNS:example.com'.

This bug might be related to a new version of ansible or python.