### PR TITLE
AdHoc (cert-creation) Enable recreation of certificates

### DIFF
--- a/tasks/lets_encrypt.yml
+++ b/tasks/lets_encrypt.yml
@@ -63,7 +63,7 @@
     challenge: "{{ lets_encrypt_challenge_type }}"
     agreement: "{{ lets_encrypt_agreement }}"
     csr: "/etc/ssl/requests/{{ lets_encrypt_resource_name }}.csr"
-    dest: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.crt"
+    dest: "{{ build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
   register: acme_data
 
 - name: "Set whether needs update"
@@ -95,7 +95,7 @@
     challenge: "{{ lets_encrypt_challenge_type }}"
     agreement: "{{ lets_encrypt_agreement }}"
     csr: "/etc/ssl/requests/{{ lets_encrypt_resource_name }}.csr"
-    dest: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.crt"
+    dest: "{{ build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
     data: "{{ acme_data }}"
   when: lets_encrypt_certificate_invalidated == true
 
@@ -108,10 +108,10 @@
     loop_var: "resource"
   when: lets_encrypt_certificate_invalidated == true
 
-- name: "Copy the issued certificate to the build dir for assembly"
+- name: "Copy the issued certificate to the ssl cert directory for reference"
   copy:
-    src: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.crt"
-    dest: "{{ build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
+    src: "{{ build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
+    dest: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.crt"
     remote_src: "yes"
   when: lets_encrypt_certificate_invalidated == true
 
@@ -121,7 +121,7 @@
     dest: "{{ build_dir.path }}/02-chain.crt"
   when: lets_encrypt_certificate_invalidated == true
 
-- name: "Assemble the full chain"
+- name: "Assemble the full chain certificate"
   assemble:
     src: "{{ build_dir.path }}"
     dest: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.fullchain.crt"

--- a/tasks/lets_encrypt.yml
+++ b/tasks/lets_encrypt.yml
@@ -8,7 +8,7 @@
   tempfile:
     state: "directory"
     suffix: "pki"
-  register: "build_dir"
+  register: "lets_encrypt_certificate_build_dir"
 
 - name: "Create the base PKI directories"
   file:
@@ -63,7 +63,7 @@
     challenge: "{{ lets_encrypt_challenge_type }}"
     agreement: "{{ lets_encrypt_agreement }}"
     csr: "/etc/ssl/requests/{{ lets_encrypt_resource_name }}.csr"
-    dest: "{{ build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
+    dest: "{{ lets_encrypt_certificate_build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
   register: acme_data
 
 - name: "Set whether needs update"
@@ -95,7 +95,7 @@
     challenge: "{{ lets_encrypt_challenge_type }}"
     agreement: "{{ lets_encrypt_agreement }}"
     csr: "/etc/ssl/requests/{{ lets_encrypt_resource_name }}.csr"
-    dest: "{{ build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
+    dest: "{{ lets_encrypt_certificate_build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
     data: "{{ acme_data }}"
   when: lets_encrypt_certificate_invalidated == true
 
@@ -110,7 +110,7 @@
 
 - name: "Copy the issued certificate to the ssl cert directory for reference"
   copy:
-    src: "{{ build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
+    src: "{{ lets_encrypt_certificate_build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
     dest: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.crt"
     remote_src: "yes"
   when: lets_encrypt_certificate_invalidated == true
@@ -118,12 +118,12 @@
 - name: "Fetch the CA certificate"
   get_url:
     url: "https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem.txt"
-    dest: "{{ build_dir.path }}/02-chain.crt"
+    dest: "{{ lets_encrypt_certificate_build_dir.path }}/02-chain.crt"
   when: lets_encrypt_certificate_invalidated == true
 
 - name: "Assemble the full chain certificate"
   assemble:
-    src: "{{ build_dir.path }}"
+    src: "{{ lets_encrypt_certificate_build_dir.path }}"
     dest: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.fullchain.crt"
     owner: "root"
     mode: "u=r,g=r,o=r"
@@ -132,4 +132,4 @@
 - name: "Cleanup build dir"
   file:
     state: "absent"
-    path: "{{ build_dir.path }}/"
+    path: "{{ lets_encrypt_certificate_build_dir.path }}/"

--- a/tasks/lets_encrypt.yml
+++ b/tasks/lets_encrypt.yml
@@ -33,14 +33,6 @@
   openssl_privatekey:
     path: "/etc/ssl/private/{{ lets_encrypt_resource_name }}.key"
 
-# See http://docs.ansible.com/ansible/latest/playbooks_filters.html#extracting-values-from-containers
-- name: "Create the list of domains valid for this certificate"
-  set_fact:
-    lets_encrypt_domains: "{{ lets_encrypt_resources | json_query('[*].domain') | list }}"
-- name: "Create the list of alt domains valid for this certificate"
-  set_fact:
-    lets_encrypt_subject_alt_names: "{{ lets_encrypt_domains | map('regex_replace', '^(.*)$', 'DNS:\\1') | list }}"
-
 - name: "Create the certificate signing request"
   openssl_csr:
     path: "/etc/ssl/requests/{{ lets_encrypt_resource_name }}.csr"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,38 @@
 ---
 - include: "dependencies.yml"
 
+# See http://docs.ansible.com/ansible/latest/playbooks_filters.html#extracting-values-from-containers
+- name: "Create the list of domains valid for this certificate"
+  set_fact:
+    lets_encrypt_domains: "{{ lets_encrypt_resources | json_query('[*].domain') | list }}"
+- name: "Create the list of alt domains valid for this certificate"
+  set_fact:
+    lets_encrypt_subject_alt_names: "{{ lets_encrypt_domains | map('regex_replace', '^(.*)$', 'DNS:\\1') | list }}"
+
+- name: "Check the validity and expiry"
+  openssl_certificate:
+    valid_in: "{{ lets_encrypt_renew_limit * 3600 }}"
+    path: "/etc/ssl/certs/{{ lets_encrypt_resource_name }}.crt"
+    provider: assertonly
+    has_expired: no
+    subject_alt_name: "{{ lets_encrypt_subject_alt_names }}"
+    subject_alt_name_strict: yes
+  ignore_errors: yes
+  register: lets_encrypt_validity_check
+
 # Create the /.well-known/acme-challenge dir
 - include: "wellknown.yml"
   vars:
     lets_encrypt_resource_state: present
   when:
     - lets_encrypt_challenge_type == 'http-01'
+    - lets_encrypt_validity_check.failed == true
 
 
 - include: "lets_encrypt.yml"
-  when: lets_encrypt_common_name is not undefined
+  when:
+    - lets_encrypt_common_name is not undefined
+    - lets_encrypt_validity_check.failed == true
 
 
 # Remove the /.well-known/acme-challenge dir
@@ -19,6 +41,7 @@
     lets_encrypt_resource_state: absent
   when:
     - lets_encrypt_challenge_type == 'http-01'
+    - lets_encrypt_validity_check.failed == true
 
 # Concatenate crt & key for HAproxy SSL support
 - include: "haproxy.yml"
@@ -26,3 +49,4 @@
     - lets_encrypt_ssl_mode == 'haproxy'
     - lets_encrypt_common_name is not undefined
     - lets_encrypt_challenge_type == 'http-01'
+    - lets_encrypt_validity_check.failed == true


### PR DESCRIPTION
It turns out that old certificates are not renewed or updated with new
configurations (for example additional or changed domains) while
delployments.

It turns out that removing the certifificate in the path
/etc/ssl/certs/XXXX.lets_encrypt.crt
is not touched even when it should be changed. Removing this file is
getting the renewing process into success. This indicates that the
let's encrypt component is not overwriting existing files.

This now fixed with writing the new certificate into an temporary
directory and copy it over to the cert dir later with ansible.