### PR TITLE
Adhoc (acme) Update acme to version 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to 
 [Semantic Versioning](http://semver.org/).
 
+## 2.0.0
+
+### changed
+- Update to use acme v2, as acme v1 was depricated and removed by letsencrypt
+- Use latest ansible version 1.8.0 (changes might be incompatible with older versions of ansible)
+
+
 ## 1.1.1
 
 ### changed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ itself.
 ## Requirements
 
 - Internet Access
-- Ansible 2.4.0+
+- Ansible 2.8.0+
 - Python2[1](https://github.com/ansible/ansible/issues/30690)
 - pip (installs dependencies if required)
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,8 +11,8 @@ lets_encrypt_agreement: "https://letsencrypt.org/documents/LE-SA-v1.2-November-1
 ## The directory used for Lets Encrypt to generate certificates
 ## Defaults to staging for testing.
 lets_encrypt_mode: "stage"
-lets_encrypt_url_prod: "https://acme-v01.api.letsencrypt.org/directory" # PROD
-lets_encrypt_url_stage: "https://acme-staging.api.letsencrypt.org/directory" # STAGE
+lets_encrypt_url_prod: "https://acme-v02.api.letsencrypt.org/directory" # PROD
+lets_encrypt_url_stage: "https://acme-staging-v02.api.letsencrypt.org/directory" # STAGE
 
 lets_encrypt_directory: "{{ vars['lets_encrypt_url_'+lets_encrypt_mode] }}" # set STAGE or PROD URL
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,7 +16,7 @@ galaxy_info:
   # - CC-BY
   license: license (GPLv2, CC-BY, etc)
 
-  min_ansible_version: 2.4
+  min_ansible_version: 2.8
 
   # If this a Container Enabled role, provide the minimum Ansible Container version.
   # min_ansible_container_version:

--- a/tasks/lets_encrypt.yml
+++ b/tasks/lets_encrypt.yml
@@ -47,13 +47,15 @@
     subject_alt_name: "{{ lets_encrypt_subject_alt_names }}"
 
 - name: "Make the request of the Lets Encrypt API"
-  letsencrypt:
-    remaining_days: {{ lets_encrypt_renew_limit }}
+  acme_certificate:
+    remaining_days: "{{ lets_encrypt_renew_limit }}"
     acme_directory: "{{ lets_encrypt_directory }}"
+    acme_version: 2
     account_email: "{{ lets_encrypt_account_email }}"
     account_key: "/etc/ssl/private/lets_encrypt.key"
     challenge: "{{ lets_encrypt_challenge_type }}"
     agreement: "{{ lets_encrypt_agreement }}"
+    terms_agreed: yes
     csr: "/etc/ssl/requests/{{ lets_encrypt_resource_name }}.csr"
     dest: "{{ lets_encrypt_certificate_build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
   register: acme_data
@@ -81,11 +83,13 @@
     - lets_encrypt_challenge_type == "dns-01"
 
 - name: "Ask Lets Encrypt to validate and issue a new key"
-  letsencrypt:
+  acme_certificate:
     acme_directory: "{{ lets_encrypt_directory }}"
+    acme_version: 2
     account_key: "/etc/ssl/private/lets_encrypt.key"
     challenge: "{{ lets_encrypt_challenge_type }}"
     agreement: "{{ lets_encrypt_agreement }}"
+    terms_agreed: yes
     csr: "/etc/ssl/requests/{{ lets_encrypt_resource_name }}.csr"
     dest: "{{ lets_encrypt_certificate_build_dir.path }}/01-{{ lets_encrypt_resource_name }}.crt"
     data: "{{ acme_data }}"


### PR DESCRIPTION
As letsencrypt has deprecated acme_v1 and disabled it's acme_v1
endpoint. We need to change to acme_v2. This requires to use a new
interface. This change introduces an update, but this also requires an
update of ansible, that is reflected in the minimal supported version.

We do not need to support acme_v1 anymore, because service was
discontinued.